### PR TITLE
Fetches back built package with elevated privileges

### DIFF
--- a/tasks/build_debian_package.yml
+++ b/tasks/build_debian_package.yml
@@ -3,6 +3,7 @@
   command: dpkg-deb --build {{ build_debian_package_directory }}
 
 - name: Fetch build Debian package back to localhost.
+  become: yes
   fetch:
     src: "{{ build_debian_package_deb_file }}"
     dest: "{{ build_debian_package_local_directory }}/{{ build_debian_package_deb_file | basename }}"


### PR DESCRIPTION
Although the package is built by a normal user by default, needed to su up to fetch the package back, otherwise was getting "No such file or directory", even though the path was correct. Likely related to SSH
hardening. The elevated privileges only apply to the remote host, and not to the Ansible controller where the built debian package will land. This preserves the ability to run the role _without_ become/sudo.