### PR TITLE
Don't automagically handle list fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,10 +66,25 @@ Example Playbook
 - name: Build Debian package.
   hosts: buildserver
   become: yes
+  vars:
+    deb_package_dependencies:
+      - emacs
+      - vim
   roles:
     - role: freedomofpress.build-debian-package
-  tags: build
+      build_debian_package_control_fields:
+        Package: wizard-hat
+        Version: 0.7.2
+        Priority: optional
+        Architecture: amd64
+        Depends: "{{ deb_package_dependencies|join(',') }}"
+        Maintainer: Yours Truly
+        Description: A wizard's true power lies in knowing the names of things.
+      tags: build
 ```
+
+The example above lists only dependencies and no files,
+creating a metapackage.
 
 Further Reading
 ---------------

--- a/templates/debian-control-file.j2
+++ b/templates/debian-control-file.j2
@@ -1,3 +1,3 @@
 {% for key, value in build_debian_package_control_fields.iteritems() %}
-{{ key }}: {{ value|join(',') if key in build_debian_package_list_vars else value }}
+{{ key }}: {{ value }}
 {% endfor %}

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -28,10 +28,3 @@ build_debian_package_required_control_fields:
 build_debian_package_recommended_control_fields:
   - Section
   - Priority
-
-# Certain control fields can accept a list, which should be comma-separated.
-# This list var provides a lookup table for special handling.
-build_debian_package_list_vars:
-  - Depends
-  - Conflicts
-  - Replaces


### PR DESCRIPTION
The previous handling of control fields that supported lists of items was bizarre and unintuitive. It tried too hard to be helpful and ended up breaking a lot of expectations about how Ansible works.

Explicit is better than implicit, so if you want a list of packages e.g. in `Depends`, use a `|join(',')` on the list when passing vars to the role. Updated example play in the README to illustrate.