### PR TITLE
Support multiple debian distros

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -12,10 +12,9 @@ build_debian_package_files_directories: []
 # Simple files to to copy. Again, use a dict with "src" and "dest" attributes.
 build_debian_package_extra_files: []
 
-build_debian_package_base_dependencies:
-  - build-essential
-  - gcc-4.8
-  - make
+# Using distro-specific vars files to set the correct gcc version.
+# The vars include will be skipped if you define this var.
+# build_debian_package_base_dependencies: []
 
 # List of filepaths that will be removed from the package tree prior to building.
 # It's safer to remove as a separate task than to use an rsync filter.

--- a/tasks/include_distro_vars.yml
+++ b/tasks/include_distro_vars.yml
@@ -1,0 +1,11 @@
+---
+- name: Include distro-specific vars.
+  include_vars: "{{ item }}"
+  with_first_found:
+    - "{{ ansible_distribution }}_{{ ansible_distribution_release }}.yml"
+    - "{{ ansible_distribution }}.yml"
+
+- name: Set base packages var.
+  set_fact:
+    build_debian_package_base_dependencies: "{{ __build_debian_package_base_dependencies }}"
+  when: build_debian_package_base_dependencies is not defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
 # tasks file for build-debian-package
+- include: include_distro_vars.yml
+  tags: vars
+
 - include: validate_variables.yml
   tags: validate
 

--- a/vars/Debian_jessie.yml
+++ b/vars/Debian_jessie.yml
@@ -1,0 +1,5 @@
+---
+__build_debian_package_base_dependencies:
+  - build-essential
+  - gcc-4.8
+  - make

--- a/vars/Debian_sid.yml
+++ b/vars/Debian_sid.yml
@@ -1,0 +1,5 @@
+---
+__build_debian_package_base_dependencies:
+  - build-essential
+  - gcc-6
+  - make

--- a/vars/Debian_stretch.yml
+++ b/vars/Debian_stretch.yml
@@ -1,0 +1,5 @@
+---
+__build_debian_package_base_dependencies:
+  - build-essential
+  - gcc-6
+  - make


### PR DESCRIPTION
A fairly straightforward change. The old setup was assuming Debian Jessie, and so the role failed under Debian Stretch. Updated the vars logic to be distro-specific. At present this will cause failures on Ubuntu hosts, but it's a much cleaner layout for adding those vars (or accepting a PR for such) in the future.